### PR TITLE
package+ bootstrapping

### DIFF
--- a/package+.el
+++ b/package+.el
@@ -46,10 +46,17 @@
 ;;
 ;; Example:
 ;;
+;;    (package-initialize)
+;;    (add-to-list 'package-archives
+;;      '("melpa" . "http://melpa.milkbox.net/packages/") t)
+;;    (unless (package-installed-p 'package+)
+;;      (package-install 'package+))
+;;
 ;;    (package-manifest 'ag
 ;;                      'expand-region
 ;;                      'magit
 ;;                      'melpa
+;;                      'package+
 ;;                      'paredit
 ;;                      'ruby-mode
 ;;                      'ssh


### PR DESCRIPTION
Expand the example to show how to install package+ using the packaging system.

Autoload package-manifest, so that it's available as soon as package+ is installed.
