### PR TITLE
Use variable package-manifest-cleanup to control package deletion behavi...

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@
 Provides extensions to `package.el` for Emacs 24 and later.
 
 Declares a manifest of packages that should be installed on this
-system, installing any missing packages and removing any installed
-packages that are not in the manifest.
+system, installing any missing packages and possibly removing any
+installed packages that are not in the manifest.
 
 This makes it easy to keep a list of packages under version control
 and replicated across all your environments, without having to have
 all the packages themselves under version control.
+
+If you do not wish to delete installed packages that are not listed in
+the manifest, set the variable `package-manifest-cleanup` to `nil`.
+Setting this to nil also allows for multiple calls to
+`package-manifest`, which may be convenient for organizing emacs
+initialization.
 
 Example:
 

--- a/package+.el
+++ b/package+.el
@@ -84,6 +84,11 @@
 (unless (fboundp 'package-cleanup)
   (require 'cl)
 
+  (defcustom package-manifest-cleanup t
+    "If true, installed packages which are not listed in the manifest will be deleted."
+    :group 'package+
+    :type 'boolean)
+
   (defun package-details-for (name)
     (let ((v (cdr (assoc name (append package-alist package-archive-contents)))))
       (and v (if (consp v)
@@ -148,7 +153,8 @@ control."
   (condition-case err
       (mapc 'package-maybe-install (package-transitive-closure manifest))
     (error (message "Couldn't install package: %s" err)))
-  (package-cleanup manifest))
+  (when package-manifest-cleanup
+    (package-cleanup manifest)))
 
 (provide 'package+)
 


### PR DESCRIPTION
...our.

If t, then packages not in the manifest are deleted as before.
If nil, packages not listed in the manifest will not be deleted.
This allows for multiple calls to package-manifest.
